### PR TITLE
feat: add category showcase and refine ui

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,10 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
 import './App.css';
+import { Stethoscope, ShoppingCart, LogIn, UserPlus, Phone, Mail, MapPin } from 'lucide-react';
+import { Button } from './components/ui/button';
+import { Card, CardContent, CardFooter, CardTitle } from './components/ui/card';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 
 // Auth Context
 const AuthContext = createContext();
@@ -30,7 +35,7 @@ const AuthProvider = ({ children }) => {
 
   const login = async (username, password) => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/auth/login`, {
+      const response = await fetch(`${BACKEND_URL}/api/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -57,7 +62,7 @@ const AuthProvider = ({ children }) => {
 
   const register = async (userData) => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/auth/register`, {
+      const response = await fetch(`${BACKEND_URL}/api/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -101,15 +106,16 @@ const Header = ({ onLoginClick, onRegisterClick, onCartClick, cartCount, onProdu
   const { user, logout } = useAuth();
 
   return (
-    <header className="bg-gradient-to-r from-blue-600 to-blue-800 text-white shadow-xl sticky top-0 z-50">
+    <header className="backdrop-blur-md bg-gradient-to-r from-blue-600/90 to-cyan-600/90 text-white shadow-lg sticky top-0 z-50">
       <div className="container mx-auto px-4 py-4">
         <div className="flex justify-between items-center">
           <div className="flex items-center space-x-reverse space-x-8">
-            <h1 
-              className="text-2xl font-bold text-right cursor-pointer hover:text-blue-200 transition-colors"
+            <h1
+              className="text-2xl font-bold text-right cursor-pointer hover:text-blue-200 transition-colors flex items-center gap-2"
               onClick={() => setCurrentPage('home')}
             >
-              پیک سلامت
+              <Stethoscope className="w-6 h-6" />
+              <span>پیک سلامت</span>
             </h1>
             <nav className="hidden md:flex space-x-reverse space-x-6">
               <button 
@@ -137,42 +143,44 @@ const Header = ({ onLoginClick, onRegisterClick, onCartClick, cartCount, onProdu
           </div>
           
           <div className="flex items-center space-x-reverse space-x-4">
-            <button 
+            <Button
               onClick={onCartClick}
-              className="relative hover:text-blue-200 transition-colors bg-blue-700 px-3 py-2 hover:bg-blue-600"
+              className="relative flex items-center gap-2 bg-blue-700 hover:bg-blue-600 px-3 py-2"
+              aria-label="سبد خرید"
             >
-              🛒 سبد خرید
+              <ShoppingCart className="w-5 h-5" />
+              <span className="hidden sm:inline">سبد خرید</span>
               {cartCount > 0 && (
                 <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs h-6 w-6 flex items-center justify-center animate-pulse">
                   {cartCount}
                 </span>
               )}
-            </button>
-            
+            </Button>
+
             {user ? (
               <div className="flex items-center space-x-reverse space-x-4">
                 <span className="text-sm">سلام {user.full_name}</span>
-                <button 
+                <Button
                   onClick={logout}
-                  className="bg-red-500 hover:bg-red-600 px-4 py-2 transition-colors shadow-lg"
+                  className="bg-red-500 hover:bg-red-600 px-4 py-2 shadow-lg"
                 >
                   خروج
-                </button>
+                </Button>
               </div>
             ) : (
               <div className="flex space-x-reverse space-x-2">
-                <button 
+                <Button
                   onClick={onLoginClick}
-                  className="bg-blue-500 hover:bg-blue-600 px-4 py-2 transition-colors shadow-lg"
+                  className="bg-blue-500 hover:bg-blue-600 px-4 py-2 shadow-lg flex items-center gap-1"
                 >
-                  ورود
-                </button>
-                <button 
+                  <LogIn className="w-4 h-4" /> ورود
+                </Button>
+                <Button
                   onClick={onRegisterClick}
-                  className="bg-green-500 hover:bg-green-600 px-4 py-2 transition-colors shadow-lg"
+                  className="bg-green-500 hover:bg-green-600 px-4 py-2 shadow-lg flex items-center gap-1"
                 >
-                  ثبت نام
-                </button>
+                  <UserPlus className="w-4 h-4" /> ثبت نام
+                </Button>
               </div>
             )}
           </div>
@@ -198,15 +206,18 @@ const HeroSection = ({ onProductsClick }) => {
               ما محصولات و خدمات بهداشتی با کیفیت را ارائه می دهیم
             </p>
             <div className="flex space-x-reverse space-x-4">
-              <button 
+              <Button
                 onClick={onProductsClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-4 text-lg font-semibold transition-all shadow-xl hover:shadow-2xl transform hover:-translate-y-1 pulse-glow"
+                className="bg-blue-600 hover:bg-blue-700 px-8 py-4 text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:-translate-y-1 pulse-glow"
               >
                 اکنون خرید کنید
-              </button>
-              <button className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 text-lg font-semibold transition-all shadow-lg">
+              </Button>
+              <Button
+                variant="outline"
+                className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 text-lg font-semibold shadow-lg"
+              >
                 مشاهده کاتالوگ
-              </button>
+              </Button>
             </div>
           </div>
           <div className="lg:w-1/2 mt-10 lg:mt-0 hero-image">
@@ -225,19 +236,78 @@ const HeroSection = ({ onProductsClick }) => {
   );
 };
 
+// Categories Section
+const CategoriesSection = ({ onSelectCategory }) => {
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch(`${BACKEND_URL}/api/categories`);
+        if (res.ok) {
+          const data = await res.json();
+          setCategories(data);
+        }
+      } catch (err) {
+        console.error('Error fetching categories:', err);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  const colors = [
+    'from-teal-100 to-blue-50',
+    'from-pink-100 to-rose-50',
+    'from-yellow-100 to-amber-50',
+    'from-indigo-100 to-purple-50'
+  ];
+
+  return (
+    <section className="py-12 bg-white">
+      <div className="container mx-auto px-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {categories.map((cat, idx) => (
+            <Card
+              key={cat.name}
+              className={`relative overflow-hidden rounded-2xl shadow-md bg-gradient-to-br ${colors[idx % colors.length]}`}
+            >
+              <CardContent className="p-6 flex flex-col items-end text-right h-full">
+                <h3 className="text-lg font-bold mb-4">{cat.name}</h3>
+                <Button
+                  onClick={() => onSelectCategory(cat.name)}
+                  className="mt-auto bg-white text-blue-600 border-2 border-blue-600 hover:bg-blue-50 px-4 py-2 rounded-xl"
+                >
+                  مشاهده محصولات
+                </Button>
+              </CardContent>
+              {cat.image && (
+                <img
+                  src={cat.image}
+                  alt={cat.name}
+                  className="w-24 h-24 object-cover absolute left-4 bottom-4 rounded-lg shadow-lg"
+                />
+              )}
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
 // Product Card Component
 const ProductCard = ({ product, onAddToCart, onProductClick }) => {
   const hasDiscount = product.discount_percentage;
   const discountedPrice = hasDiscount ? product.price * (1 - product.discount_percentage / 100) : product.price;
 
   return (
-    <div 
-      className="bg-white shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-3 product-card group cursor-pointer"
+    <Card
+      className="product-card rounded-2xl border border-gray-200 hover:shadow-xl transition-all duration-500 transform hover:-translate-y-2 group cursor-pointer"
       onClick={() => onProductClick(product)}
     >
       <div className="relative overflow-hidden">
-        <img 
-          src={product.image} 
+        <img
+          src={product.image}
           alt={product.name}
           className="w-full h-48 object-cover transition-transform duration-500 group-hover:scale-110"
         />
@@ -248,32 +318,34 @@ const ProductCard = ({ product, onAddToCart, onProductClick }) => {
         )}
         <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
       </div>
-      <div className="p-6">
-        <h3 className="text-xl font-bold text-gray-800 mb-2 text-right group-hover:text-blue-600 transition-colors">{product.name}</h3>
+      <CardContent className="p-6">
+        <CardTitle className="text-xl font-bold text-gray-800 mb-2 text-right group-hover:text-blue-600 transition-colors">
+          {product.name}
+        </CardTitle>
         <p className="text-gray-600 mb-4 text-right text-sm leading-relaxed">{product.description}</p>
-        <div className="flex justify-between items-center">
-          <button 
-            onClick={(e) => {
-              e.stopPropagation();
-              onAddToCart(product);
-            }}
-            className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 font-semibold transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-1"
-          >
-            افزودن به سبد
-          </button>
-          <div className="text-right">
-            {hasDiscount && (
-              <span className="text-lg text-gray-400 line-through block">
-                {product.price.toLocaleString()} تومان
-              </span>
-            )}
-            <span className="text-2xl font-bold text-blue-600">
-              {Math.round(discountedPrice).toLocaleString()} تومان
+      </CardContent>
+      <CardFooter className="flex justify-between items-center">
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            onAddToCart(product);
+          }}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-1"
+        >
+          افزودن به سبد
+        </Button>
+        <div className="text-right">
+          {hasDiscount && (
+            <span className="text-lg text-gray-400 line-through block">
+              {product.price.toLocaleString()} تومان
             </span>
-          </div>
+          )}
+          <span className="text-2xl font-bold text-blue-600">
+            {Math.round(discountedPrice).toLocaleString()} تومان
+          </span>
         </div>
-      </div>
-    </div>
+      </CardFooter>
+    </Card>
   );
 };
 
@@ -290,7 +362,7 @@ const ProductsSection = ({ onAddToCart, featured = true }) => {
   const fetchProducts = async () => {
     try {
       const endpoint = featured ? '/api/products/featured' : '/api/products';
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}${endpoint}`);
+      const response = await fetch(`${BACKEND_URL}${endpoint}`);
       if (response.ok) {
         const data = await response.json();
         setProducts(featured ? data : data.products || data);
@@ -357,7 +429,7 @@ const ProductDetailModal = ({ product, onClose, onAddToCart }) => {
 
   const fetchReviews = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/products/${product.id}/reviews`);
+      const response = await fetch(`${BACKEND_URL}/api/products/${product.id}/reviews`);
       if (response.ok) {
         const data = await response.json();
         setReviews(data);
@@ -375,7 +447,7 @@ const ProductDetailModal = ({ product, onClose, onAddToCart }) => {
     }
 
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/products/${product.id}/reviews`, {
+      const response = await fetch(`${BACKEND_URL}/api/products/${product.id}/reviews`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -556,12 +628,12 @@ const ProductDetailModal = ({ product, onClose, onAddToCart }) => {
 };
 
 // Full Products Page
-const ProductsPage = ({ onAddToCart }) => {
+const ProductsPage = ({ onAddToCart, initialCategory = '' }) => {
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [categories, setCategories] = useState([]);
   const [filters, setFilters] = useState({
-    category: '',
+    category: initialCategory,
     search: '',
     min_price: '',
     max_price: '',
@@ -583,9 +655,16 @@ const ProductsPage = ({ onAddToCart }) => {
     fetchProducts();
   }, [filters, pagination.page]);
 
+  useEffect(() => {
+    if (initialCategory) {
+      setFilters(prev => ({ ...prev, category: initialCategory }));
+      setPagination(prev => ({ ...prev, page: 1 }));
+    }
+  }, [initialCategory]);
+
   const fetchCategories = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/products/categories`);
+      const response = await fetch(`${BACKEND_URL}/api/products/categories`);
       if (response.ok) {
         const data = await response.json();
         setCategories(data);
@@ -604,7 +683,7 @@ const ProductsPage = ({ onAddToCart }) => {
         ...Object.fromEntries(Object.entries(filters).filter(([_, v]) => v !== ''))
       });
 
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/products?${params}`);
+      const response = await fetch(`${BACKEND_URL}/api/products?${params}`);
       if (response.ok) {
         const data = await response.json();
         setProducts(data.products || []);
@@ -774,7 +853,7 @@ const DiscountsPage = ({ onAddToCart }) => {
 
   const fetchDiscountedProducts = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/products/discounted`);
+      const response = await fetch(`${BACKEND_URL}/api/products/discounted`);
       if (response.ok) {
         const data = await response.json();
         setDiscountedProducts(data);
@@ -786,7 +865,7 @@ const DiscountsPage = ({ onAddToCart }) => {
 
   const fetchDiscountCodes = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/discounts`);
+      const response = await fetch(`${BACKEND_URL}/api/discounts`);
       if (response.ok) {
         const data = await response.json();
         setDiscountCodes(data);
@@ -877,7 +956,7 @@ const ArticlesSection = () => {
 
   const fetchArticles = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/articles`);
+      const response = await fetch(`${BACKEND_URL}/api/articles`);
       if (response.ok) {
         const data = await response.json();
         setArticles(data.slice(0, 3)); // Show only first 3 articles
@@ -939,7 +1018,7 @@ const ServicesSection = () => {
 
   const fetchServices = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/services`);
+      const response = await fetch(`${BACKEND_URL}/api/services`);
       if (response.ok) {
         const data = await response.json();
         setServices(data);
@@ -1313,7 +1392,7 @@ const CartModal = ({ isOpen, onClose, cartItems, onRemoveItem, onCheckout }) => 
     try {
       const productDetails = await Promise.all(
         cartItems.map(async (item) => {
-          const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/products/${item.product_id}`);
+          const response = await fetch(`${BACKEND_URL}/api/products/${item.product_id}`);
           if (response.ok) {
             const product = await response.json();
             return { ...product, quantity: item.quantity };
@@ -1456,7 +1535,7 @@ const CheckoutModal = ({ isOpen, onClose, cartItems, totalAmount, onOrderComplet
     if (!discountCode.trim()) return;
     
     try {
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/discounts/validate`, {
+      const response = await fetch(`${BACKEND_URL}/api/discounts/validate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1496,7 +1575,7 @@ const CheckoutModal = ({ isOpen, onClose, cartItems, totalAmount, onOrderComplet
         discount_code: discountCode || null
       };
 
-      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/orders`, {
+      const response = await fetch(`${BACKEND_URL}/api/orders`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1628,11 +1707,13 @@ const CheckoutModal = ({ isOpen, onClose, cartItems, totalAmount, onOrderComplet
 // Footer Component
 const Footer = () => {
   return (
-    <footer className="bg-gray-800 text-white py-12">
+    <footer className="bg-gray-900 text-white py-12">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="text-right">
-            <h3 className="text-2xl font-bold mb-4">پیک سلامت</h3>
+            <h3 className="text-2xl font-bold mb-4 flex items-center justify-end gap-2">
+              <Stethoscope className="w-5 h-5" /> پیک سلامت
+            </h3>
             <p className="text-gray-300 leading-relaxed">
               فروشگاه آنلاین تجهیزات پزشکی با بهترین کیفیت و قیمت
             </p>
@@ -1663,15 +1744,15 @@ const Footer = () => {
             <ul className="space-y-3 text-gray-300">
               <li className="flex items-center justify-end space-x-reverse space-x-2">
                 <span>۰۲۱-۱۲۳۴۵۶۷۸</span>
-                <span>📞</span>
+                <Phone className="w-5 h-5" />
               </li>
               <li className="flex items-center justify-end space-x-reverse space-x-2">
                 <span>info@pickselamat.com</span>
-                <span>📧</span>
+                <Mail className="w-5 h-5" />
               </li>
               <li className="flex items-center justify-end space-x-reverse space-x-2">
                 <span>تهران، خیابان ولیعصر</span>
-                <span>📍</span>
+                <MapPin className="w-5 h-5" />
               </li>
             </ul>
           </div>
@@ -1690,6 +1771,7 @@ const Footer = () => {
 // Main App Component
 function App() {
   const [currentPage, setCurrentPage] = useState('home');
+  const [selectedCategory, setSelectedCategory] = useState('');
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showRegisterModal, setShowRegisterModal] = useState(false);
   const [showCartModal, setShowCartModal] = useState(false);
@@ -1798,13 +1880,14 @@ function App() {
   const renderCurrentPage = () => {
     switch (currentPage) {
       case 'products':
-        return <ProductsPage onAddToCart={handleAddToCart} />;
+        return <ProductsPage onAddToCart={handleAddToCart} initialCategory={selectedCategory} />;
       case 'discounts':
         return <DiscountsPage onAddToCart={handleAddToCart} />;
       default:
         return (
           <>
             <HeroSection onProductsClick={() => setCurrentPage('products')} />
+            <CategoriesSection onSelectCategory={(cat) => { setSelectedCategory(cat); setCurrentPage('products'); }} />
             <ProductsSection onAddToCart={handleAddToCart} />
             <ServicesSection />
             <ArticlesSection />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,20 @@ import { Stethoscope, ShoppingCart, LogIn, UserPlus, Phone, Mail, MapPin } from 
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardFooter, CardTitle } from './components/ui/card';
 
+const SplitText = ({ text, className }) => (
+  <span className={className} aria-label={text}>
+    {text.split('').map((char, idx) => (
+      <span
+        key={idx}
+        className="inline-block opacity-0 animate-fade-in-up"
+        style={{ animationDelay: `${idx * 40}ms` }}
+      >
+        {char}
+      </span>
+    ))}
+  </span>
+);
+
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 
 // Auth Context
@@ -198,9 +212,11 @@ const HeroSection = ({ onProductsClick }) => {
         <div className="flex flex-col lg:flex-row items-center">
           <div className="lg:w-1/2 text-right hero-content">
             <h2 className="text-4xl lg:text-6xl font-bold text-gray-800 mb-6 leading-tight">
-              برای پزشکان
+              <SplitText text="برای پزشکان" />
               <br />
-              <span className="text-blue-600 gradient-text">و متخصصان پزشکی</span>
+              <span className="text-blue-600 gradient-text">
+                <SplitText text="و متخصصان پزشکی" />
+              </span>
             </h2>
             <p className="text-xl text-gray-600 mb-8 leading-relaxed">
               ما محصولات و خدمات بهداشتی با کیفیت را ارائه می دهیم
@@ -208,13 +224,13 @@ const HeroSection = ({ onProductsClick }) => {
             <div className="flex space-x-reverse space-x-4">
               <Button
                 onClick={onProductsClick}
-                className="bg-blue-600 hover:bg-blue-700 px-8 py-4 text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:-translate-y-1 pulse-glow"
+                className="px-8 py-4 text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:-translate-y-1 pulse-glow"
               >
                 اکنون خرید کنید
               </Button>
               <Button
                 variant="outline"
-                className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 text-lg font-semibold shadow-lg"
+                className="px-8 py-4 text-lg font-semibold"
               >
                 مشاهده کاتالوگ
               </Button>
@@ -350,10 +366,9 @@ const ProductCard = ({ product, onAddToCart, onProductClick }) => {
 };
 
 // Products Section
-const ProductsSection = ({ onAddToCart, featured = true }) => {
+const ProductsSection = ({ onAddToCart, onProductClick, featured = true }) => {
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [selectedProduct, setSelectedProduct] = useState(null);
 
   useEffect(() => {
     fetchProducts();
@@ -394,241 +409,22 @@ const ProductsSection = ({ onAddToCart, featured = true }) => {
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           {products.map((product) => (
-            <ProductCard 
-              key={product.id} 
-              product={product} 
+            <ProductCard
+              key={product.id}
+              product={product}
               onAddToCart={onAddToCart}
-              onProductClick={setSelectedProduct}
+              onProductClick={onProductClick}
             />
           ))}
         </div>
       </div>
-
-      {/* Product Detail Modal */}
-      {selectedProduct && (
-        <ProductDetailModal 
-          product={selectedProduct} 
-          onClose={() => setSelectedProduct(null)}
-          onAddToCart={onAddToCart}
-        />
-      )}
     </section>
   );
 };
 
 // Product Detail Modal
-const ProductDetailModal = ({ product, onClose, onAddToCart }) => {
-  const [reviews, setReviews] = useState([]);
-  const [newReview, setNewReview] = useState({ rating: 5, comment: '' });
-  const [showReviewForm, setShowReviewForm] = useState(false);
-  const { user, token } = useAuth();
-
-  useEffect(() => {
-    fetchReviews();
-  }, [product.id]);
-
-  const fetchReviews = async () => {
-    try {
-      const response = await fetch(`${BACKEND_URL}/api/products/${product.id}/reviews`);
-      if (response.ok) {
-        const data = await response.json();
-        setReviews(data);
-      }
-    } catch (error) {
-      console.error('Error fetching reviews:', error);
-    }
-  };
-
-  const submitReview = async (e) => {
-    e.preventDefault();
-    if (!user) {
-      alert('برای ثبت نظر باید وارد شوید');
-      return;
-    }
-
-    try {
-      const response = await fetch(`${BACKEND_URL}/api/products/${product.id}/reviews`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify(newReview),
-      });
-
-      if (response.ok) {
-        setNewReview({ rating: 5, comment: '' });
-        setShowReviewForm(false);
-        fetchReviews();
-        alert('نظر شما با موفقیت ثبت شد');
-      }
-    } catch (error) {
-      console.error('Error submitting review:', error);
-      alert('خطا در ثبت نظر');
-    }
-  };
-
-  const hasDiscount = product.discount_percentage;
-  const discountedPrice = hasDiscount ? product.price * (1 - product.discount_percentage / 100) : product.price;
-
-  return (
-    <div 
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-      onClick={onClose}
-    >
-      <div 
-        className="bg-white max-w-4xl w-full max-h-[90vh] overflow-y-auto shadow-2xl transform transition-all"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="relative">
-          <button 
-            onClick={onClose}
-            className="absolute top-4 left-4 text-white bg-black bg-opacity-50 hover:bg-opacity-70 w-10 h-10 flex items-center justify-center z-10 transition-all"
-          >
-            ✕
-          </button>
-          
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 p-8">
-            {/* Product Image */}
-            <div className="relative">
-              <img 
-                src={product.image} 
-                alt={product.name}
-                className="w-full h-96 object-cover shadow-lg"
-              />
-              {hasDiscount && (
-                <div className="absolute top-4 right-4 bg-red-500 text-white px-4 py-2 font-bold">
-                  {product.discount_percentage}% تخفیف
-                </div>
-              )}
-            </div>
-
-            {/* Product Info */}
-            <div className="text-right">
-              <h1 className="text-3xl font-bold text-gray-800 mb-4">{product.name}</h1>
-              <div className="mb-6">
-                <span className="bg-blue-100 text-blue-800 px-3 py-1 text-sm font-semibold">
-                  {product.category}
-                </span>
-              </div>
-              
-              <p className="text-gray-600 mb-6 leading-relaxed text-lg">{product.description}</p>
-              
-              <div className="mb-6">
-                <span className="text-gray-600">موجودی: </span>
-                <span className="font-semibold text-green-600">{product.stock} عدد</span>
-              </div>
-
-              <div className="mb-8">
-                {hasDiscount && (
-                  <span className="text-2xl text-gray-400 line-through block mb-2">
-                    {product.price.toLocaleString()} تومان
-                  </span>
-                )}
-                <span className="text-4xl font-bold text-blue-600">
-                  {Math.round(discountedPrice).toLocaleString()} تومان
-                </span>
-              </div>
-
-              <button 
-                onClick={() => onAddToCart(product)}
-                className="w-full bg-blue-600 hover:bg-blue-700 text-white px-8 py-4 text-xl font-bold transition-all shadow-xl hover:shadow-2xl transform hover:-translate-y-1 mb-4"
-              >
-                افزودن به سبد خرید
-              </button>
-
-              <button 
-                className="w-full border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 text-xl font-bold transition-all"
-              >
-                خرید فوری
-              </button>
-            </div>
-          </div>
-
-          {/* Reviews Section */}
-          <div className="border-t bg-gray-50 p-8">
-            <div className="flex justify-between items-center mb-6">
-              <h3 className="text-2xl font-bold text-gray-800">نظرات کاربران</h3>
-              {user && (
-                <button 
-                  onClick={() => setShowReviewForm(!showReviewForm)}
-                  className="bg-green-600 hover:bg-green-700 text-white px-6 py-2 font-semibold transition-colors"
-                >
-                  ثبت نظر
-                </button>
-              )}
-            </div>
-
-            {showReviewForm && (
-              <form onSubmit={submitReview} className="mb-8 bg-white p-6 shadow-lg">
-                <div className="mb-4">
-                  <label className="block text-gray-700 text-sm font-bold mb-2 text-right">
-                    امتیاز
-                  </label>
-                  <select
-                    value={newReview.rating}
-                    onChange={(e) => setNewReview(prev => ({...prev, rating: parseInt(e.target.value)}))}
-                    className="w-full px-3 py-2 border border-gray-300 focus:outline-none focus:border-blue-500"
-                  >
-                    {[1,2,3,4,5].map(rating => (
-                      <option key={rating} value={rating}>{rating} ستاره</option>
-                    ))}
-                  </select>
-                </div>
-                
-                <div className="mb-4">
-                  <label className="block text-gray-700 text-sm font-bold mb-2 text-right">
-                    نظر شما
-                  </label>
-                  <textarea
-                    value={newReview.comment}
-                    onChange={(e) => setNewReview(prev => ({...prev, comment: e.target.value}))}
-                    className="w-full px-3 py-2 border border-gray-300 focus:outline-none focus:border-blue-500 text-right"
-                    rows="4"
-                    required
-                  />
-                </div>
-                
-                <button
-                  type="submit"
-                  className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 font-semibold transition-colors"
-                >
-                  ثبت نظر
-                </button>
-              </form>
-            )}
-
-            <div className="space-y-4">
-              {reviews.length === 0 ? (
-                <p className="text-gray-600 text-center py-8">هنوز نظری ثبت نشده است</p>
-              ) : (
-                reviews.map((review) => (
-                  <div key={review.id} className="bg-white p-6 shadow">
-                    <div className="flex justify-between items-start mb-2">
-                      <div className="text-right">
-                        <div className="font-semibold text-gray-800">{review.user_name}</div>
-                        <div className="text-yellow-500">
-                          {'★'.repeat(review.rating)}{'☆'.repeat(5-review.rating)}
-                        </div>
-                      </div>
-                      <div className="text-sm text-gray-500">
-                        {new Date(review.created_at).toLocaleDateString('fa-IR')}
-                      </div>
-                    </div>
-                    <p className="text-gray-700 text-right">{review.comment}</p>
-                  </div>
-                ))
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
 // Full Products Page
-const ProductsPage = ({ onAddToCart, initialCategory = '' }) => {
+const ProductsPage = ({ onAddToCart, onProductClick, initialCategory = '' }) => {
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [categories, setCategories] = useState([]);
@@ -645,7 +441,6 @@ const ProductsPage = ({ onAddToCart, initialCategory = '' }) => {
     total: 0,
     total_pages: 0
   });
-  const [selectedProduct, setSelectedProduct] = useState(null);
 
   useEffect(() => {
     fetchCategories();
@@ -797,11 +592,11 @@ const ProductsPage = ({ onAddToCart, initialCategory = '' }) => {
             
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
               {products.map((product) => (
-                <ProductCard 
-                  key={product.id} 
-                  product={product} 
+                <ProductCard
+                  key={product.id}
+                  product={product}
                   onAddToCart={onAddToCart}
-                  onProductClick={setSelectedProduct}
+                  onProductClick={onProductClick}
                 />
               ))}
             </div>
@@ -828,20 +623,12 @@ const ProductsPage = ({ onAddToCart, initialCategory = '' }) => {
         )}
       </div>
 
-      {/* Product Detail Modal */}
-      {selectedProduct && (
-        <ProductDetailModal 
-          product={selectedProduct} 
-          onClose={() => setSelectedProduct(null)}
-          onAddToCart={onAddToCart}
-        />
-      )}
     </div>
   );
 };
 
 // Discounts Page
-const DiscountsPage = ({ onAddToCart }) => {
+const DiscountsPage = ({ onAddToCart, onProductClick }) => {
   const [discountedProducts, setDiscountedProducts] = useState([]);
   const [discountCodes, setDiscountCodes] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -923,11 +710,11 @@ const DiscountsPage = ({ onAddToCart }) => {
           <h2 className="text-3xl font-bold text-gray-800 mb-8 text-center">محصولات با تخفیف ویژه</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
             {discountedProducts.map((product) => (
-              <ProductCard 
-                key={product.id} 
-                product={product} 
+              <ProductCard
+                key={product.id}
+                product={product}
                 onAddToCart={onAddToCart}
-                onProductClick={() => {}}
+                onProductClick={onProductClick}
               />
             ))}
           </div>
@@ -939,6 +726,152 @@ const DiscountsPage = ({ onAddToCart }) => {
           <p className="text-xl mb-6">تا ۵۰٪ تخفیف روی محصولات منتخب</p>
           <div className="text-6xl font-bold mb-4">۲۵٪</div>
           <p className="text-lg">تخفیف روی تمام تجهیزات پزشکی</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Product Detail Page
+const ProductDetailPage = ({ product, onAddToCart, onBack }) => {
+  const [reviews, setReviews] = useState([]);
+  const [newReview, setNewReview] = useState({ rating: 5, comment: '' });
+  const [showReviewForm, setShowReviewForm] = useState(false);
+  const { user, token } = useAuth();
+
+  useEffect(() => {
+    fetchReviews();
+  }, [product.id]);
+
+  const fetchReviews = async () => {
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/products/${product.id}/reviews`);
+      if (res.ok) {
+        const data = await res.json();
+        setReviews(data);
+      }
+    } catch (err) {
+      console.error('Error fetching reviews:', err);
+    }
+  };
+
+  const submitReview = async (e) => {
+    e.preventDefault();
+    if (!user) {
+      alert('برای ثبت نظر باید وارد شوید');
+      return;
+    }
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/products/${product.id}/reviews`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify(newReview)
+      });
+      if (res.ok) {
+        setNewReview({ rating: 5, comment: '' });
+        setShowReviewForm(false);
+        fetchReviews();
+      }
+    } catch (err) {
+      console.error('Error submitting review:', err);
+    }
+  };
+
+  const hasDiscount = product.discount_percentage;
+  const discountedPrice = hasDiscount ? product.price * (1 - product.discount_percentage / 100) : product.price;
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4">
+        <Button onClick={onBack} className="mb-6">بازگشت</Button>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 bg-white p-8 shadow-lg">
+          <div className="relative">
+            <img src={product.image} alt={product.name} className="w-full h-96 object-cover" />
+            {hasDiscount && (
+              <div className="absolute top-4 right-4 bg-red-500 text-white px-4 py-2 font-bold">
+                {product.discount_percentage}% تخفیف
+              </div>
+            )}
+          </div>
+          <div className="text-right">
+            <h1 className="text-3xl font-bold text-gray-800 mb-4">{product.name}</h1>
+            <p className="text-gray-600 mb-6 leading-relaxed">{product.description}</p>
+            <div className="mb-6">
+              <span className="text-gray-600">موجودی: </span>
+              <span className="font-semibold text-green-600">{product.stock} عدد</span>
+            </div>
+            <div className="mb-8">
+              {hasDiscount && (
+                <span className="text-2xl text-gray-400 line-through block mb-2">
+                  {product.price.toLocaleString()} تومان
+                </span>
+              )}
+              <span className="text-4xl font-bold text-blue-600">
+                {Math.round(discountedPrice).toLocaleString()} تومان
+              </span>
+            </div>
+            <Button onClick={() => onAddToCart(product)} className="w-full mb-4">
+              افزودن به سبد خرید
+            </Button>
+          </div>
+        </div>
+        <div className="mt-8 bg-white p-8 shadow-lg">
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="text-2xl font-bold text-gray-800">نظرات کاربران</h3>
+            {user && (
+              <Button onClick={() => setShowReviewForm(!showReviewForm)}>
+                ثبت نظر
+              </Button>
+            )}
+          </div>
+          {showReviewForm && (
+            <form onSubmit={submitReview} className="mb-8">
+              <div className="mb-4">
+                <label className="block text-gray-700 text-sm font-bold mb-2 text-right">امتیاز</label>
+                <select
+                  value={newReview.rating}
+                  onChange={(e) => setNewReview(prev => ({ ...prev, rating: parseInt(e.target.value) }))}
+                  className="w-full px-3 py-2 border border-gray-300 focus:outline-none focus:border-blue-500"
+                >
+                  {[1,2,3,4,5].map(r => (
+                    <option key={r} value={r}>{r} ستاره</option>
+                  ))}
+                </select>
+              </div>
+              <div className="mb-4">
+                <label className="block text-gray-700 text-sm font-bold mb-2 text-right">نظر شما</label>
+                <textarea
+                  value={newReview.comment}
+                  onChange={(e) => setNewReview(prev => ({ ...prev, comment: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 focus:outline-none focus:border-blue-500 text-right"
+                  rows="4"
+                  required
+                />
+              </div>
+              <Button type="submit">ثبت نظر</Button>
+            </form>
+          )}
+          <div className="space-y-4">
+            {reviews.length === 0 ? (
+              <p className="text-gray-600 text-center py-8">هنوز نظری ثبت نشده است</p>
+            ) : (
+              reviews.map(r => (
+                <div key={r.id} className="bg-gray-50 p-4">
+                  <div className="flex justify-between mb-2">
+                    <div className="text-right">
+                      <div className="font-semibold text-gray-800">{r.user_name}</div>
+                      <div className="text-yellow-500">{'★'.repeat(r.rating)}{'☆'.repeat(5-r.rating)}</div>
+                    </div>
+                    <div className="text-sm text-gray-500">{new Date(r.created_at).toLocaleDateString('fa-IR')}</div>
+                  </div>
+                  <p className="text-gray-700 text-right">{r.comment}</p>
+                </div>
+              ))
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -1008,7 +941,7 @@ const ArticlesSection = () => {
 };
 
 // Services Section
-const ServicesSection = () => {
+const ServicesSection = ({ onServiceClick, onProductsClick }) => {
   const [services, setServices] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -1061,9 +994,12 @@ const ServicesSection = () => {
               <div className="absolute bottom-0 left-0 right-0 p-8 text-white">
                 <h3 className="text-2xl font-bold mb-4 text-right">{service.title}</h3>
                 <p className="mb-6 text-right opacity-90 leading-relaxed">{service.description}</p>
-                <button className="bg-white text-gray-800 px-8 py-3 font-bold hover:bg-gray-100 transition-colors shadow-lg transform hover:-translate-y-1">
+                <Button
+                  onClick={() => (index === 0 ? onServiceClick(service) : onProductsClick())}
+                  className="bg-white/30 text-white hover:bg-white/40 px-8 py-3 font-bold"
+                >
                   {index === 0 ? 'بیشتر بدانید' : 'مشاهده محصولات'}
-                </button>
+                </Button>
               </div>
               {index === 1 && (
                 <div className="absolute top-4 right-4 bg-red-500 text-white px-6 py-3 font-bold animate-pulse shadow-lg">
@@ -1077,6 +1013,27 @@ const ServicesSection = () => {
     </section>
   );
 };
+
+// Service Detail Page
+const ServiceDetailPage = ({ service, onBack }) => (
+  <div className="min-h-screen bg-gray-50 py-8">
+    <div className="container mx-auto px-4">
+      <Button onClick={onBack} className="mb-6">بازگشت</Button>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 bg-white p-8 shadow-lg">
+        <img src={service.image} alt={service.title} className="w-full h-96 object-cover" />
+        <div className="text-right">
+          <h1 className="text-3xl font-bold text-gray-800 mb-4">{service.title}</h1>
+          <p className="text-gray-600 mb-6 leading-relaxed">{service.description}</p>
+          <ul className="space-y-2 mb-4 list-disc pr-5">
+            {service.features.map((f, i) => (
+              <li key={i} className="text-gray-700">{f}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+);
 
 // Features Section
 const FeaturesSection = () => {
@@ -1778,6 +1735,8 @@ function App() {
   const [showCheckoutModal, setShowCheckoutModal] = useState(false);
   const [cartItems, setCartItems] = useState([]);
   const [orderSuccess, setOrderSuccess] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState(null);
+  const [selectedService, setSelectedService] = useState(null);
 
   const { user, token, loading } = useAuth();
 
@@ -1861,6 +1820,16 @@ function App() {
     setShowCheckoutModal(false);
   };
 
+  const handleProductClick = (product) => {
+    setSelectedProduct(product);
+    setCurrentPage('product-detail');
+  };
+
+  const handleServiceClick = (service) => {
+    setSelectedService(service);
+    setCurrentPage('service-detail');
+  };
+
   const calculateTotalAmount = () => {
     // This will be calculated in CartModal based on actual product prices
     return 0;
@@ -1880,16 +1849,28 @@ function App() {
   const renderCurrentPage = () => {
     switch (currentPage) {
       case 'products':
-        return <ProductsPage onAddToCart={handleAddToCart} initialCategory={selectedCategory} />;
+        return <ProductsPage onAddToCart={handleAddToCart} onProductClick={handleProductClick} initialCategory={selectedCategory} />;
       case 'discounts':
-        return <DiscountsPage onAddToCart={handleAddToCart} />;
+        return <DiscountsPage onAddToCart={handleAddToCart} onProductClick={handleProductClick} />;
+      case 'product-detail':
+        return selectedProduct ? (
+          <ProductDetailPage
+            product={selectedProduct}
+            onAddToCart={handleAddToCart}
+            onBack={() => setCurrentPage('products')}
+          />
+        ) : null;
+      case 'service-detail':
+        return selectedService ? (
+          <ServiceDetailPage service={selectedService} onBack={() => setCurrentPage('home')} />
+        ) : null;
       default:
         return (
           <>
             <HeroSection onProductsClick={() => setCurrentPage('products')} />
             <CategoriesSection onSelectCategory={(cat) => { setSelectedCategory(cat); setCurrentPage('products'); }} />
-            <ProductsSection onAddToCart={handleAddToCart} />
-            <ServicesSection />
+            <ProductsSection onAddToCart={handleAddToCart} onProductClick={handleProductClick} />
+            <ServicesSection onServiceClick={handleServiceClick} onProductsClick={() => setCurrentPage('products')} />
             <ArticlesSection />
             <FeaturesSection />
           </>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -302,7 +302,7 @@ const ProductCard = ({ product, onAddToCart, onProductClick }) => {
 
   return (
     <Card
-      className="product-card rounded-2xl border border-gray-200 hover:shadow-xl transition-all duration-500 transform hover:-translate-y-2 group cursor-pointer"
+      className="product-card rounded-2xl border border-gray-200 hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-3 group cursor-pointer"
       onClick={() => onProductClick(product)}
     >
       <div className="relative overflow-hidden">

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,17 +4,13 @@ import { Stethoscope, ShoppingCart, LogIn, UserPlus, Phone, Mail, MapPin } from 
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardFooter, CardTitle } from './components/ui/card';
 
-const SplitText = ({ text, className }) => (
-  <span className={className} aria-label={text}>
-    {text.split('').map((char, idx) => (
-      <span
-        key={idx}
-        className="inline-block opacity-0 animate-fade-in-up"
-        style={{ animationDelay: `${idx * 40}ms` }}
-      >
-        {char}
-      </span>
-    ))}
+// Fade-in utility that keeps complex scripts connected
+const FadeInText = ({ children, delay = 0, className = '' }) => (
+  <span
+    className={`inline-block opacity-0 animate-fade-in-up ${className}`.trim()}
+    style={{ animationDelay: `${delay}ms` }}
+  >
+    {children}
   </span>
 );
 
@@ -212,10 +208,10 @@ const HeroSection = ({ onProductsClick }) => {
         <div className="flex flex-col lg:flex-row items-center">
           <div className="lg:w-1/2 text-right hero-content">
             <h2 className="text-4xl lg:text-6xl font-bold text-gray-800 mb-6 leading-tight">
-              <SplitText text="برای پزشکان" />
+              <FadeInText>برای پزشکان</FadeInText>
               <br />
               <span className="text-blue-600 gradient-text">
-                <SplitText text="و متخصصان پزشکی" />
+                <FadeInText delay={200}>و متخصصان پزشکی</FadeInText>
               </span>
             </h2>
             <p className="text-xl text-gray-600 mb-8 leading-relaxed">
@@ -285,7 +281,7 @@ const CategoriesSection = ({ onSelectCategory }) => {
           {categories.map((cat, idx) => (
             <Card
               key={cat.name}
-              className={`relative overflow-hidden rounded-2xl shadow-md bg-gradient-to-br ${colors[idx % colors.length]}`}
+              className={`relative overflow-hidden rounded-2xl shadow-md hover:shadow-xl transition-transform hover:-translate-y-1 bg-gradient-to-br ${colors[idx % colors.length]}`}
             >
               <CardContent className="p-6 flex flex-col items-end text-right h-full">
                 <h3 className="text-lg font-bold mb-4">{cat.name}</h3>
@@ -300,7 +296,7 @@ const CategoriesSection = ({ onSelectCategory }) => {
                 <img
                   src={cat.image}
                   alt={cat.name}
-                  className="w-24 h-24 object-cover absolute left-4 bottom-4 rounded-lg shadow-lg"
+                  className="w-24 h-24 object-cover absolute right-4 bottom-4 rounded-lg shadow-lg"
                 />
               )}
             </Card>
@@ -1937,4 +1933,5 @@ const AppWithAuth = () => {
   );
 };
 
+export { HeroSection };
 export default AppWithAuth;

--- a/frontend/src/Button.test.jsx
+++ b/frontend/src/Button.test.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { Button } from './components/ui/button';
+
+it('renders button text', () => {
+  const html = ReactDOMServer.renderToString(<Button>دکمه تست</Button>);
+  expect(html).toContain('دکمه تست');
+});

--- a/frontend/src/HeroSection.test.jsx
+++ b/frontend/src/HeroSection.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { HeroSection } from './App';
+
+it('renders hero text', () => {
+  const html = ReactDOMServer.renderToString(<HeroSection onProductsClick={() => {}} />);
+  expect(html).toContain('برای پزشکان');
+  expect(html).toContain('و متخصصان پزشکی');
+});

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -5,25 +5,25 @@ import { cva } from "class-variance-authority";
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all backdrop-blur-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-white/20 text-blue-700 border border-white/40 shadow hover:bg-white/30",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-red-500/80 text-white border border-red-300 shadow-sm hover:bg-red-500",
         outline:
-          "border border-input shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-blue-600/40 text-blue-700 hover:bg-white/20",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary/80 text-secondary-foreground shadow-sm hover:bg-secondary/60",
+        ghost: "hover:bg-white/20",
+        link: "text-blue-700 underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
+        sm: "h-8 rounded-full px-3 text-xs",
+        lg: "h-10 rounded-full px-8",
         icon: "h-9 w-9",
       },
     },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
     margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    font-family: 'Vazirmatn', -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
         "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
         "Helvetica Neue", sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -85,3 +85,18 @@ code {
     @apply bg-background text-foreground;
     }
 }
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.5s forwards;
+}

--- a/start_app.sh
+++ b/start_app.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting Medical Store Application..."
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$PROJECT_ROOT"
+
+# Setup Python virtual environment
+if [ ! -d venv ]; then
+  python3 -m venv venv
+fi
+source venv/bin/activate
+pip install -r backend/requirements.txt
+
+# Wait for MongoDB to be available
+until nc -z localhost 27017; do
+  echo "Waiting for MongoDB on port 27017..."
+  sleep 2
+done
+echo "MongoDB is up."
+
+# Start backend server in the background
+(
+  cd backend
+  uvicorn server:app --host 0.0.0.0 --port 8000 &
+)
+
+# Navigate to frontend and start development server
+cd frontend
+npm install --force
+npm start
+

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,27 @@
+import types
+from fastapi.testclient import TestClient
+import backend.server as server
+
+# Stub database collection
+server.products_collection = types.SimpleNamespace(
+    aggregate=lambda pipeline: [
+        {"_id": "لوازم پزشکی", "image": "img.png"}
+    ],
+    find=lambda filter, projection: [
+        {"id": "1", "name": "محصول ویژه", "featured": True, "price": 1000}
+    ]
+)
+
+client = TestClient(server.app)
+
+def test_categories_endpoint():
+    response = client.get("/api/categories")
+    assert response.status_code == 200
+    assert response.json() == [{"name": "لوازم پزشکی", "image": "img.png"}]
+
+def test_featured_products_endpoint():
+    response = client.get("/api/products/featured")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert data[0]["featured"] is True

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,13 @@
+import types
+from fastapi.testclient import TestClient
+import backend.server as server
+
+# Patch the MongoDB client to avoid real database calls
+server.client = types.SimpleNamespace(admin=types.SimpleNamespace(command=lambda *args, **kwargs: {"ok": 1}))
+
+client = TestClient(server.app)
+
+def test_health_endpoint():
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- expose `/api/categories` to serve category names with representative images
- highlight categories on the homepage with gradient cards and quick links to filtered products
- adopt Vazirmatn font and rounded card styling for a modern medical shop look

## Testing
- `python -m py_compile backend/server.py`
- `cd frontend && CI=true yarn test --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4dde608832499dc1991cf4c428e